### PR TITLE
add back gcc install dir

### DIFF
--- a/swift-define
+++ b/swift-define
@@ -39,6 +39,11 @@ SWIFTPM_CONFIGURATION="${SWIFTPM_CONFIGURATION:=release}"
 SWIFT_PACKAGE_SRCDIR="${SWIFT_PACKAGE_SRCDIR:=$SRC_ROOT/swift-hello}"
 SWIFT_PACKAGE_BUILDDIR="${SWIFT_PACKAGE_BUILDDIR:=$SWIFT_PACKAGE_SRCDIR/.build}"
 CROSS_TOOLCHAIN_FILE="${CROSS_TOOLCHAIN_FILE:=$SRC_ROOT/build/build-toolchain-${SWIFT_TARGET_ARCH}.cmake}"
+if [ -d ${STAGING_DIR} ]; then
+    GCC_INSTALL_DIR=$(dirname $(find ${STAGING_DIR} -name crtbegin.o))
+else
+    GCC_INSTALL_DIR=${STAGING_DIR}
+fi
 
 # Build Paths
 LLVM_SRCDIR=$SRC_ROOT/downloads/llvm-project
@@ -72,8 +77,8 @@ INSTALL_TAR=${INSTALL_TAR:=$SRC_ROOT/build/$SWIFT_VERSION-$SWIFT_TARGET_ARCH.tar
 PREBUILT_XCTOOLCHAIN=$SRC_ROOT/downloads/${SWIFT_VERSION}-osx.pkg
 
 # Compilation flags
-RUNTIME_FLAGS="-w -fuse-ld=lld --sysroot=${STAGING_DIR} -target ${SWIFT_TARGET_NAME} ${EXTRA_FLAGS}"
-LINK_FLAGS="--sysroot=${STAGING_DIR} -target ${SWIFT_TARGET_NAME} ${EXTRA_FLAGS}"
+RUNTIME_FLAGS="-w -fuse-ld=lld --sysroot=${STAGING_DIR} --gcc-install-dir=${GCC_INSTALL_DIR} -target ${SWIFT_TARGET_NAME} ${EXTRA_FLAGS}"
+LINK_FLAGS="--sysroot=${STAGING_DIR} --gcc-install-dir=${GCC_INSTALL_DIR} -target ${SWIFT_TARGET_NAME} ${EXTRA_FLAGS}"
 ASM_FLAGS="--sysroot=${STAGING_DIR} -target ${SWIFT_TARGET_NAME}"
 
 SWIFTC_FLAGS="-target ${SWIFT_TARGET_NAME} \


### PR DESCRIPTION
Using yocto sysroot, the gcc install dir seems to be different. I am not sure if this is the root cause, but this solves it.
While the solution is hacky, it is better than broken.

This is the error:
    InstalledDir: /home/xaver/swift-installation/swift-6.1-RELEASE-ubuntu24.04/usr/bin
    Found candidate GCC installation: /opt/swift-armv7/sysroot-imx8/lib/gcc/aarch64-poky-linux/13.3.0
    Found candidate GCC installation: /opt/swift-armv7/sysroot-imx8/usr/lib/gcc/aarch64-poky-linux/13.3.0
     "/home/xaver/swift-installation/swift-6.1-RELEASE-ubuntu24.04/usr/bin/ld.lld" --sysroot=/opt/swift-armv7/sysroot-imx8 -EL -z relro --hash-style=gnu --eh-frame-hdr -m aarch64linux -pie -dynamic-linker /lib/ld-linux-aarch64.so.1 -o cmTC_510c3 /opt/swift-armv7/sysroot-imx8/lib/Scrt1.o /opt/swift-armv7/sysroot-imx8/lib/crti.o crtbeginS.o -L/opt/swift-armv7/sysroot-imx8/lib/aarch64-poky-linux/13.3.0 -L/opt/swift-armv7/sysroot-imx8/lib/aarch64-poky-linux/13.3.0/ -L/opt/swift-armv7/sysroot-imx8/lib -L/opt/swift-armv7/sysroot-imx8/usr/lib CMakeFiles/cmTC_510c3.dir/testCCompiler.c.o -lgcc --as-needed -lgcc_s --no-as-needed -lc -lgcc --as-needed -lgcc_s --no-as-needed crtendS.o /opt/swift-armv7/sysroot-imx8/lib/crtn.o
    ld.lld: error: cannot open crtbeginS.o: No such file or directory
    ld.lld: error: cannot open crtendS.o: No such file or directory
    clang: error: linker command failed with exit code 1 (use -v to see invocation)
    ninja: build stopped: subcommand failed.

the two files are here:
sysroot-imx8/usr/lib/aarch64-poky-linux/13.3.0/
├── crtbegin.o
├── crtbeginS.o
├── crtbeginT.o
├── crtend.o
├── crtendS.o
├── crtfastmath.o
├── include
│   ├── acc_prof.h
│   ├── omp.h
│   ├── openacc.h
│   └── sanitizer
│       ├── asan_interface.h
│       ├── common_interface_defs.h
│       ├── hwasan_interface.h
│       ├── lsan_interface.h
│       └── tsan_interface.h
├── libgcc.a
├── libgcc_eh.a
└── libgcov.a

3 directories, 17 files


This solution is not new, it partially reverts this commit: #a28319a83142a3bd8d4e68bf4c95d92307befed6