### PR TITLE
#10: Add patch for FileManager.attributesOfFileSystem crash on armv7

### DIFF
--- a/fetch-sources.sh
+++ b/fetch-sources.sh
@@ -2,14 +2,13 @@
 set -e
 source swift-define
 
-mkdir -p ./downloads
+DOWNLOAD_DIR=$(pwd)/downloads
+
+mkdir -p $DOWNLOAD_DIR
 
 # Fetch sources
-cd ./downloads
+cd $DOWNLOAD_DIR
 if [[ -d "$SWIFT_SRCDIR" ]]; then
-    cd swift-corelibs-foundation
-    git stash
-
     echo "$SWIFT_SRCDIR exists"
     cd $SWIFT_SRCDIR
     git stash
@@ -70,5 +69,13 @@ patch -d . -p1 --forward <$SRC_ROOT/patches/0002-Add-arm-to-float16support-for-m
 if [[ $SWIFT_VERSION == *"5.9"* ]] || [[ $SWIFT_VERSION == *"5.10-"* ]]; then
     echo "Apply Foundation strlcpy/strlcat patch"
     cd ../swift-corelibs-foundation
+    git stash
     patch -d . -p1 <$SRC_ROOT/patches/0002-Foundation-check-for-strlcpy-strlcat.patch
+fi
+
+if [[ $SWIFT_VERSION == *"6."* ]] && [ -d $DOWNLOAD_DIR/swift-foundation ]; then
+    echo "Apply Foundation FileManager.attributesOfFileSystem patch"
+    cd ../swift-foundation
+    git stash
+    patch -d . -p1 <$SRC_ROOT/patches/0003-Foundation-FileManager.attributesOfFileSystem-crash-armv7.patch
 fi

--- a/patches/0003-Foundation-FileManager.attributesOfFileSystem-crash-armv7.patch
+++ b/patches/0003-Foundation-FileManager.attributesOfFileSystem-crash-armv7.patch
@@ -1,0 +1,30 @@
+From 4d072beec765f2972fe9af6a807967519f8e8c03 Mon Sep 17 00:00:00 2001
+From: "Jesse L. Zamora" <xtremekforever@gmail.com>
+Date: Fri, 6 Feb 2026 11:14:33 -0500
+Subject: [PATCH] Fix for FileManager.attributesOfFileSystem crash on armv7
+
+---
+ .../FileManager/FileManager+Files.swift                     | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+index b2666cc..d127923 100644
+--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
++++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+@@ -741,10 +741,10 @@ extension _FileManagerImpl {
+             let blockSize = UInt64(result.f_bsize)
+             #else
+             let fsNumber = result.f_fsid
+-            let blockSize = UInt(result.f_frsize)
++            let blockSize = UInt64(result.f_frsize)
+             #endif
+-            var totalSizeBytes = result.f_blocks * blockSize
+-            var availSizeBytes = result.f_bavail * blockSize
++            var totalSizeBytes = UInt64(result.f_blocks) * blockSize
++            var availSizeBytes = UInt64(result.f_bavail) * blockSize
+             var totalFiles = result.f_files
+             var availFiles = result.f_ffree
+             
+-- 
+2.52.0
+


### PR DESCRIPTION
This fixes the crash described in the linked ticket on Swift 6.2.3 on armv7. It can probably be cherry-picked/applied to older versions of Swift as well.