### PR TITLE
Fix .Cxx interop in swift-hello example in Swift 6.3

### DIFF
--- a/build-sysroot.sh
+++ b/build-sysroot.sh
@@ -13,6 +13,11 @@ if [ -z $SYSROOT ]; then
 fi
 SYSROOT=$(pwd)/$SYSROOT
 
+# These are only for armhf Debian sysroots. Expand to support more architectures if needed.
+MULTILIB_DIR=arm-linux-gnueabihf
+MULTILIB_LIBRARIES=(libc.so.6 libm.so.6 libpthread.so.0)
+MUTLILIB_LD=ld-linux-armhf.so.3
+
 DISTRIBUTION="$DISTRIBUTION_NAME:$DISTRIUBTION_VERSION"
 
 case $DISTRIUBTION_VERSION in
@@ -101,7 +106,7 @@ else
     echo "Starting up qemu emulation"
     docker run --privileged --rm tonistiigi/binfmt --install all
 
-    CONTAINER_NAME=swift-armhf-sysroot
+    CONTAINER_NAME=swift-armhf-sysroot-$DISTRIBUTION_VERSION
 
     echo "Building $DISTRIBUTION distribution for sysroot"
     docker rm --force $CONTAINER_NAME
@@ -113,8 +118,12 @@ else
 
     echo "Extracting sysroot folders to $SYSROOT"
     rm -rf $SYSROOT
-    mkdir -p $SYSROOT/usr
-    docker cp $CONTAINER_NAME:/lib $SYSROOT/lib
+    mkdir -p $SYSROOT/lib $SYSROOT/lib/$MULTILIB_DIR $SYSROOT/usr
+    docker cp $CONTAINER_NAME:/lib/$MULTILIB_DIR/$MUTLILIB_LD $SYSROOT/lib/$MULTILIB_DIR/$MUTLILIB_LD
+    docker cp $CONTAINER_NAME:/lib/$MUTLILIB_LD $SYSROOT/lib/$MUTLILIB_LD
+    for lib in "${MULTILIB_LIBRARIES[@]}"; do
+        docker cp $CONTAINER_NAME:/lib/$MULTILIB_DIR/$lib $SYSROOT/lib/$MULTILIB_DIR/$lib
+    done
     docker cp $CONTAINER_NAME:/usr/include $SYSROOT/usr/include
     docker cp $CONTAINER_NAME:/usr/lib $SYSROOT/usr/lib
 

--- a/build-sysroot.sh
+++ b/build-sysroot.sh
@@ -15,7 +15,26 @@ SYSROOT=$(pwd)/$SYSROOT
 
 # These are only for armhf Debian sysroots. Expand to support more architectures if needed.
 MULTILIB_DIR=arm-linux-gnueabihf
-MULTILIB_LIBRARIES=(libc.so.6 libm.so.6 libpthread.so.0)
+MULTILIB_LIBRARIES=(libanl.so.1
+libBrokenLocale.so.1 \
+libc_malloc_debug.so.0 \
+libc.so.6 \
+libdl.so.2 \
+libgcc_s.so.1 \
+libmemusage.so \
+libm.so.6 \
+libnsl.so.1 \
+libnss_compat.so.2 \
+libnss_dns.so.2 \
+libnss_files.so.2 \
+libnss_hesiod.so.2 \
+libpcprofile.so \
+libpthread.so.0 \
+libresolv.so.2 \
+librt.so.1 \
+libthread_db.so.1 \
+libutil.so.1 \
+)
 MUTLILIB_LD=ld-linux-armhf.so.3
 
 DISTRIBUTION="$DISTRIBUTION_NAME:$DISTRIUBTION_VERSION"
@@ -108,7 +127,7 @@ if [[ $DISTRIBUTION_NAME = "raspios" ]]; then
     cp -P $SYSROOT_BUILD_DIR/lib/$MULTILIB_DIR/$MUTLILIB_LD $SYSROOT/lib/$MULTILIB_DIR/$MUTLILIB_LD
     cp -P $SYSROOT_BUILD_DIR/lib/$MUTLILIB_LD $SYSROOT/lib/$MUTLILIB_LD
     for lib in "${MULTILIB_LIBRARIES[@]}"; do
-        cp -P $SYSROOT_BUILD_DIR/lib/$MULTILIB_DIR/$lib $SYSROOT/lib/$MULTILIB_DIR/$lib
+        cp -P $SYSROOT_BUILD_DIR/lib/$MULTILIB_DIR/$lib $SYSROOT/lib/$MULTILIB_DIR/
     done
     cp -r $SYSROOT_BUILD_DIR/usr/include $SYSROOT/usr/include
     cp -r $SYSROOT_BUILD_DIR/usr/lib $SYSROOT/usr/lib
@@ -122,7 +141,7 @@ else
     echo "Starting up qemu emulation"
     docker run --privileged --rm tonistiigi/binfmt --install all
 
-    CONTAINER_NAME=swift-armhf-sysroot-$DISTRIBUTION_VERSION
+    CONTAINER_NAME=swift-armhf-sysroot-$DISTRIUBTION_VERSION
 
     echo "Building $DISTRIBUTION distribution for sysroot"
     docker rm --force $CONTAINER_NAME
@@ -138,7 +157,7 @@ else
     docker cp $CONTAINER_NAME:/lib/$MULTILIB_DIR/$MUTLILIB_LD $SYSROOT/lib/$MULTILIB_DIR/$MUTLILIB_LD
     docker cp $CONTAINER_NAME:/lib/$MUTLILIB_LD $SYSROOT/lib/$MUTLILIB_LD
     for lib in "${MULTILIB_LIBRARIES[@]}"; do
-        docker cp $CONTAINER_NAME:/lib/$MULTILIB_DIR/$lib $SYSROOT/lib/$MULTILIB_DIR/$lib
+        docker cp $CONTAINER_NAME:/lib/$MULTILIB_DIR/$lib $SYSROOT/lib/$MULTILIB_DIR/
     done
     docker cp $CONTAINER_NAME:/usr/include $SYSROOT/usr/include
     docker cp $CONTAINER_NAME:/usr/lib $SYSROOT/usr/lib

--- a/build-sysroot.sh
+++ b/build-sysroot.sh
@@ -69,7 +69,15 @@ fi
 # This is for supporting armv6
 if [[ $DISTRIBUTION_NAME = "raspios" ]]; then
     echo "Installing host dependencies..."
-    sudo apt update && sudo apt install qemu-user-static debootstrap
+
+    if [ $(cat /etc/os-release | grep -c "Ubuntu") -gt 0 ]; then
+        sudo apt update && sudo apt install -y qemu-user-static debootstrap
+    elif [ $(cat /etc/os-release | grep -c "Fedora") -gt 0 ]; then
+        sudo dnf install -y apt qemu-user-static debootstrap
+    else
+        echo "Unsupported host distribution! Please install qemu-user-static and debootstrap manually."
+        exit 1
+    fi
 
     mkdir artifacts && true
     cd artifacts
@@ -83,7 +91,11 @@ if [[ $DISTRIBUTION_NAME = "raspios" ]]; then
     sudo mount --bind /dev $SYSROOT_BUILD_DIR/dev
     sudo mount --bind /proc $SYSROOT_BUILD_DIR/proc
     sudo mount --bind /sys $SYSROOT_BUILD_DIR/sys
-    sudo cp /usr/bin/qemu-arm-static $SYSROOT_BUILD_DIR/usr/bin
+    QEMU_BINARY=/usr/bin/qemu-arm-static
+    if [ ! -f $QEMU_BINARY ]; then
+        QEMU_BINARY=/usr/bin/qemu-arm
+    fi
+    sudo cp $QEMU_BINARY $SYSROOT_BUILD_DIR/usr/bin
 
     echo "Installing needed dependencies..."
     sudo chroot $SYSROOT_BUILD_DIR /bin/bash -c "$INSTALL_DEPS_CMD"
@@ -92,8 +104,12 @@ if [[ $DISTRIBUTION_NAME = "raspios" ]]; then
     sudo chroot $SYSROOT_BUILD_DIR /bin/bash -c "symlinks -cr /usr/include && symlinks -cr /usr/lib"
 
     echo "Copying files from sysroot to $SYSROOT..."
-    rm -rf $SYSROOT && mkdir -p $SYSROOT/usr
-    cp -r $SYSROOT_BUILD_DIR/lib $SYSROOT/lib
+    rm -rf $SYSROOT && mkdir -p $SYSROOT/lib/$MULTILIB_DIR $SYSROOT/usr
+    cp -P $SYSROOT_BUILD_DIR/lib/$MULTILIB_DIR/$MUTLILIB_LD $SYSROOT/lib/$MULTILIB_DIR/$MUTLILIB_LD
+    cp -P $SYSROOT_BUILD_DIR/lib/$MUTLILIB_LD $SYSROOT/lib/$MUTLILIB_LD
+    for lib in "${MULTILIB_LIBRARIES[@]}"; do
+        cp -P $SYSROOT_BUILD_DIR/lib/$MULTILIB_DIR/$lib $SYSROOT/lib/$MULTILIB_DIR/$lib
+    done
     cp -r $SYSROOT_BUILD_DIR/usr/include $SYSROOT/usr/include
     cp -r $SYSROOT_BUILD_DIR/usr/lib $SYSROOT/usr/lib
 

--- a/swift-hello/Package.swift
+++ b/swift-hello/Package.swift
@@ -15,8 +15,7 @@ let package = Package(
             name: "swift-hello",
             dependencies: [],
             swiftSettings: [
-                // NOTE: .Cxx interop is broken again for tests in Swift 6.3. Disabling until we have a solution.
-                //.interoperabilityMode(.Cxx)
+                .interoperabilityMode(.Cxx)
             ]
         ),
         .testTarget(

--- a/swift-hello/Sources/swift-hello/Hello.swift
+++ b/swift-hello/Sources/swift-hello/Hello.swift
@@ -8,7 +8,7 @@
     import FoundationNetworking
 #endif
 #if canImport(CxxStdlib)
-    //import CxxStdlib
+    import CxxStdlib
 #endif
 
 @main


### PR DESCRIPTION
For some reason, in Swift 6.3 the .Cxx interop stopped compiling correctly when versions as old as 6.0 have been working with almost the same flags and sysroot. Let's figure it out.